### PR TITLE
Fix bug in load local logic (LLL)

### DIFF
--- a/import_export_development/src/libs/lib.utils.sheets.js
+++ b/import_export_development/src/libs/lib.utils.sheets.js
@@ -49,6 +49,7 @@ function SheetsUtilitiesLibrary(config) {
 SheetsUtilitiesLibrary.prototype.getCurrentActiveSpreadsheet = function() {
   var loadLocal = ((typeof this.config.sheets !== 'undefined') &&
       (typeof this.config.sheets.debugSpreadsheetId !== 'undefined') &&
+      (this.config.sheets.debugSpreadsheetId !== null) &&
       (this.config.sheets.debugSpreadsheetId !== ''));
   if (loadLocal) {
     return SpreadsheetApp.openById(this.config.sheets.debugSpreadsheetId);


### PR DESCRIPTION
Using the prd build configuration this.config.sheets.debugSpreadsheetId evaluates to null.
This wasn't catered for and was causing errors as loadLocal was true incorrectly.
Added null check to loadLocal assign